### PR TITLE
WIP feedback required

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,6 +2003,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "simple_asn1",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
  "tracing-syslog",

--- a/src/many-kvstore/Cargo.toml
+++ b/src/many-kvstore/Cargo.toml
@@ -33,3 +33,6 @@ simple_asn1 = "0.5.4"
 tracing = "0.1.28"
 tracing-subscriber = "0.3"
 tracing-syslog = { git = "https://github.com/max-heller/tracing-syslog.git", rev = "6ff222831d7a78f1068d4c8af94dea215b07f114" }
+
+[dev-dependencies]
+tempfile = "3.3.0"

--- a/src/many-kvstore/tests/common/mod.rs
+++ b/src/many-kvstore/tests/common/mod.rs
@@ -1,0 +1,45 @@
+use many::{
+    server::module::{
+        idstore::{CredentialId},
+    },
+    types::{
+        identity::{cose::testsutils::generate_random_eddsa_identity},
+    },
+    Identity, 
+};
+use many_kvstore::module::{KvStoreModuleImpl};
+
+pub struct Setup {
+    pub module_impl: KvStoreModuleImpl,
+    pub id: Identity,
+    pub cred_id: CredentialId,
+}
+
+impl Default for Setup {
+    fn default() -> Self {
+        Self::new(false)
+    }
+}
+
+impl Setup {
+    pub fn new(blockchain: bool) -> Self {
+        let id = generate_random_eddsa_identity();
+
+        let content = std::fs::read_to_string("../../staging/kvstore_state.json").unwrap();
+        let state = serde_json::from_str(&content).unwrap();
+        
+        Self {
+            module_impl: KvStoreModuleImpl::new(
+                state,
+                tempfile::tempdir().unwrap(),
+                blockchain
+            ).unwrap(),
+            id: id.identity,
+            cred_id: CredentialId(vec![1; 16].into()),
+        }
+    }
+}
+
+pub fn setup() -> Setup {
+    Setup::default()
+}

--- a/src/many-kvstore/tests/kvstore.rs
+++ b/src/many-kvstore/tests/kvstore.rs
@@ -1,0 +1,75 @@
+pub mod common;
+use crate::common::{setup, Setup};
+use minicbor::bytes::ByteVec;
+
+use many::{
+    server::module::kvstore::{
+        KvStoreModuleBackend, 
+        KvStoreCommandsModuleBackend, 
+        InfoArg,
+        PutArgs,
+        GetArgs,
+        DeleteArgs
+    },
+};
+
+#[test]
+fn kvstore_info() {
+    let Setup {
+        module_impl, 
+        id, 
+        ..
+    } = setup();
+    
+    let result = module_impl.info(&id, InfoArg {});
+    assert!(result.is_ok());
+}
+
+#[test]
+fn kvstore_put() {
+    let Setup {
+        mut module_impl, 
+        id, 
+        ..
+    } = setup();
+
+    let data = PutArgs {
+        key: ByteVec::from(vec![1]),
+        value: ByteVec::from(vec![2]),
+    };
+    
+    let result = module_impl.put(&id, data);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn kvstore_get() {
+    let Setup {
+        module_impl, 
+        id, 
+        ..
+    } = setup();
+
+    let data = GetArgs {
+        key: ByteVec::from(vec![1]),
+    };
+    
+    let result = module_impl.get(&id, data);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn kvstore_delete() {
+    let Setup {
+        mut module_impl, 
+        id, 
+        ..
+    } = setup();
+
+    let data = DeleteArgs {
+        key: ByteVec::from(vec![1]),
+    };
+    
+    let result = module_impl.delete(&id, data);
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
Feedback requested:

1. Couldn't get to read the file. I am loading state from a string current because the following didn't work:
```
        let content = std::fs::read_to_string("staging/kvstore_state.json").unwrap();
        let state = serde_json::from_str(&content).unwrap();
```
I tried ../ ../../../ etc
Returns: `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }'

2. When I run two tests, they fail. That is why you will see that I am using different persistence paths in each test. The error says they are locked for what I assume Rust runs tests concurrently.

`thread 'put' panicked at 'called `Result::unwrap()` on an `Err` value: ManyError(Reason { code: Unknown, message: Some("Unknown error: {message}"), arguments: {"message": "IO error: lock hold by current process, acquire time 1656590468 acquiring thread 123145338220544: ../somepath.db/LOCK: No locks available"} })', src/many-kvstore/tests/common/mod.rs:38:15`

What is the best practice to resolve this?

3. As you can see I have added "../somepath.db" (and the same with numbers) as the "persistence" value. What path would it be better to use?

4. In the kvstore module there is a `new()` method which we are using, there is also a `load()` method. If you look at the code, I could only run a "load" method securely by adding a new persistence in the same test as the load method. Do we care for this test at the moment? I added it anyways to make headway.

5. Similar composed question for `get`. Get should have its own test as described above, but in order to test that I am fetching the value I put (get does not fail when there is no key, it just doesn't return a value) I would need to put and get in the same test. I wrote this test but it didn't increase coverage (obviously) so the question is, do we want this test for any other reason?

6. Usually there is a "cleanup" at the end of tests to delete at the end. I am deleting the `xxxx.db` at the beginning to make sure that the tests run appropriately but it would look nice to have them be deleted at the end altogether.

7. Here are the before and after % pics. We name 70% but by adding new/load from module and info/get/put/delete methods it only reaches about 30%.

BEFORE:
![image](https://user-images.githubusercontent.com/21335275/176695838-b4d7f92d-c498-42e3-9509-bdbd90f0f70d.png)

AFTER: 
![image](https://user-images.githubusercontent.com/21335275/176695914-38c6c8d0-c684-4ae8-be6e-3ce675c70982.png)


Disclaimers:
- I still need to update the assertions
- We are not testing several different possible values to be stored and fetched
